### PR TITLE
Minor Update: Entity Category DIAGNOSTIC

### DIFF
--- a/custom_components/atonstorage/binary_sensor.py
+++ b/custom_components/atonstorage/binary_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -32,42 +32,49 @@ INVERTER_BINARY_SENSOR_DESCRIPTIONS = (
         key="grid_to_house",
         translation_key="grid_to_house",
         name="Grid to House",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_calc_function=lambda controller: controller.grid_to_house
     ),
     AtonStorageBinarySensorEntityDescription(
         key="solar_to_battery",
         translation_key="solar_to_battery",
         name="Solar to Battery",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_calc_function=lambda controller: controller.solar_to_battery
     ),
     AtonStorageBinarySensorEntityDescription(
         key="solar_to_grid",
         translation_key="solar_to_grid",
         name="Solar to Grid",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_calc_function=lambda controller: controller.solar_to_grid
     ),
     AtonStorageBinarySensorEntityDescription(
         key="battery_to_house",
         translation_key="battery_to_house",
         name="Battery to House",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_calc_function=lambda controller: controller.battery_to_house
     ),
     AtonStorageBinarySensorEntityDescription(
         key="solar_to_house",
         translation_key="solar_to_house",
         name="Solar to House",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_calc_function=lambda controller: controller.solar_to_house
     ),
     AtonStorageBinarySensorEntityDescription(
         key="grid_to_battery",
         translation_key="grid_to_battery",
         name="Grid to Battery",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_calc_function=lambda controller: controller.grid_to_battery
     ),
     AtonStorageBinarySensorEntityDescription(
         key="battery_to_grid",
         translation_key="battery_to_grid",
         name="Batter to Grid",
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_calc_function=lambda controller: controller.battery_to_grid
     ),
 )
@@ -79,7 +86,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the AtonStorage sensors."""
-    _LOGGER.debug("Set up the AtonStorage sensors")
+    _LOGGER.debug("Set up the AtonStorage binary sensors")
     entities = _create_entities(hass, entry)
     async_add_entities(entities, True)
 
@@ -135,9 +142,12 @@ class AtonStorageBinarySensorEntity(CoordinatorEntity, BinarySensorEntity):
         self._attr_name = f"{username} {self.entity_description.name}"
         self._attr_unique_id = f"{controller.serial_number}_{self.entity_description.key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, "AtonStorage " + username)},
-            name=username,
-            manufacturer="AtonStorage",
+            identifiers = {(DOMAIN, "AtonStorage " + username)},
+            name = username,
+            manufacturer = "AtonStorage",
+            sw_version =  controller.fw_Scheda,
+            serial_number = controller.serial_number,
+
         )
 
         self._register_key = self.entity_description.key

--- a/custom_components/atonstorage/sensor.py
+++ b/custom_components/atonstorage/sensor.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
@@ -57,6 +57,7 @@ INVERTER_SENSOR_DESCRIPTIONS = (
         translation_key="data",
         name="Last update",
         device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_conversion_function=lambda value: as_local(
             datetime.strptime(value, "%d/%m/%Y %H:%M:%S")
         ),
@@ -328,6 +329,7 @@ INVERTER_SENSOR_DESCRIPTIONS = (
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
         value_calc_function=lambda controller: (
             100 if int(controller.consumed_energy) == 0
             else round(100 - ((int(controller.bought_energy) / int(controller.consumed_energy)) *100), 2)
@@ -461,9 +463,11 @@ class AtonStorageSensorEntity(CoordinatorEntity, SensorEntity):
         self._attr_name = f"{username} {self.entity_description.name}"
         self._attr_unique_id = f"{controller.serial_number}_{self.entity_description.key}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, "AtonStorage " + username)},
-            name=username,
-            manufacturer="AtonStorage",
+            identifiers = {(DOMAIN, "AtonStorage " + username)},
+            name = username,
+            manufacturer = "AtonStorage",
+            sw_version =  controller.fw_Scheda,
+            serial_number = controller.serial_number,
         )
 
         self._register_key = self.entity_description.key
@@ -541,9 +545,12 @@ class AtonStorageIntegrationSensor(IntegrationSensor):
         self._entry = entry
         self._name = name
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, "AtonStorage " + username)},
-            name=username,
-            manufacturer="AtonStorage",
+            identifiers = {(DOMAIN, "AtonStorage " + username)},
+            name = username,
+            manufacturer = "AtonStorage",
+            sw_version =  controller.fw_Scheda,
+            serial_number = controller.serial_number,
+
         )
 
     @property


### PR DESCRIPTION
Set Entity Category attribute to DIAGNOSTIC for all binary sensors (power flow), "self sufficiency" and Last update" sensors;
![Screenshot 2024-04-14 at 19-08-56 Impostazioni – Home Assistant](https://github.com/wilds/hass-atonstorage/assets/76613973/6ffb9e4e-5742-4424-8099-ba05991a3c04)
 Updated DEVICEINFO with Firmware Version and Serial Number.
![Screenshot 2024-04-14 at 19-09-08 Impostazioni – Home Assistant](https://github.com/wilds/hass-atonstorage/assets/76613973/ee3f977c-88a4-44f1-adc5-832eb6aff7e5)
