### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/atonstorage/sensor.py
+++ b/custom_components/atonstorage/sensor.py
@@ -538,6 +538,7 @@ class AtonStorageIntegrationSensor(IntegrationSensor):
             unique_id=unique_id,
             unit_prefix=unit_prefix,
             unit_time=unit_time,
+            max_sub_interval=None,
         )
 
         self.entity_description = description


### PR DESCRIPTION
a seguito dell'update di HA alla versione 2024.7.0 è stato necessario aggiungere la stringa:

`max_sub_interval=None,`
nella funzione `super().__init__`

Ringrazio l'utente @maatx