### PR TITLE
Support Home Assistant 2025.8+ — pass hass to IntegrationSensor and update __init__/entity creation

### DIFF
--- a/custom_components/atonstorage/sensor.py
+++ b/custom_components/atonstorage/sensor.py
@@ -499,6 +499,7 @@ def _create_entities(hass: HomeAssistant, entry: dict):
             ):
                 entities.append(
                     AtonStorageIntegrationSensor(
+                        hass, # Home Assistant 2025.8+: IntegrationSensor requires hass 
                         integration_method="left",
                         name=f"{username} {entity_description.name}",
                         round_digits=2,
@@ -599,6 +600,7 @@ class AtonStorageIntegrationSensor(IntegrationSensor):
 
     def __init__(
         self,
+        hass, # Home Assistant 2025.8+: IntegrationSensor requires hass 
         *,
         integration_method: str,
         name: str | None,
@@ -614,6 +616,7 @@ class AtonStorageIntegrationSensor(IntegrationSensor):
     ) -> None:
         """Initialize the integration sensor."""
         super().__init__(
+            hass, # Home Assistant 2025.8+: IntegrationSensor requires hass 
             integration_method=integration_method,
             name=name,
             round_digits=round_digits,


### PR DESCRIPTION
Starting from Home Assistant 2025.8, the core IntegrationSensor constructor requires the hass instance as a positional argument. The current component calls IntegrationSensor.__init__(...) without hass, which prevents the platform from setting up on 2025.8+.

Adds hass to the AtonStorageIntegrationSensor.__init__ signature (first parameter).

Passes hass to super().__init__ (the core IntegrationSensor).

Updates all instantiations of AtonStorageIntegrationSensor(...) to provide hass as the first argument.